### PR TITLE
suggest magento-composer-installer instead of requiring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "email": "tobihille@googlemail.com"
         }
     ],
-    "require": {
+    "suggest": {
         "magento-hackathon/magento-composer-installer": "*"
     }
 }


### PR DESCRIPTION
The [FAQ](https://github.com/magento-hackathon/magento-composer-installer/blob/master/doc/FAQ.md#should-my-module-require-the-installer) of _magento-composer-installer_ asks to only **suggest** the installer.
